### PR TITLE
python venv to fix some problems 

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,7 +90,7 @@ Description=Spyguard frontend service
 
 [Service]
 Type=simple
-ExecStart=/home/${SUDO_USER}/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/frontend/main.py
+ExecStart=/usr/share/spyguard/spyguard-venv/bin/python3 /usr/share/spyguard/server/frontend/main.py
 Restart=on-abort
 KillMode=process
 
@@ -105,7 +105,7 @@ Description=Spyguard backend service
 
 [Service]
 Type=simple
-ExecStart=/home/${SUDO_USER}/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/backend/main.py
+ExecStart=/usr/share/spyguard/spyguard-venv/bin/python3 /usr/share/spyguard/server/backend/main.py
 Restart=on-abort
 KillMode=process
 
@@ -122,7 +122,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/home/${SUDO_USER}/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/backend/watchers.py
+ExecStart=/usr/share/spyguard/spyguard-venv/bin/python3 /usr/share/spyguard/server/backend/watchers.py
 Restart=on-abort
 KillMode=process
 
@@ -185,7 +185,7 @@ check_dependencies() {
        fi
    done
    echo -e "\e[39m[+] Install Python packages...\e[39m"
-   python3 -m venv /home/${SUDO_USER}/SpyGuard-venv && source /home/${SUDO_USER}/SpyGuard-venv/bin/activate && python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
+   python3 -m venv /usr/share/spyguard/spyguard-venv && source /usr/share/spyguard/spyguard-venv/bin/activate && python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
 }
 
 get_version() {

--- a/install.sh
+++ b/install.sh
@@ -171,7 +171,7 @@ check_dependencies() {
          "/usr/bin/dig"
          "/usr/bin/suricata"
          "/usr/bin/sqlite3"
-         "/usr/bin/pip3",
+         "/usr/bin/pip3"
          "/usr/sbin/arp")
 
    echo -e "\e[39m[+] Checking dependencies...\e[39m"

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,7 @@ Description=Spyguard frontend service
 
 [Service]
 Type=simple
-ExecStart=$USER_HOME/spy-venv/bin/python3 /usr/share/spyguard/server/frontend/main.py
+ExecStart=$USER_HOME/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/frontend/main.py
 Restart=on-abort
 KillMode=process
 
@@ -106,7 +106,7 @@ Description=Spyguard backend service
 
 [Service]
 Type=simple
-ExecStart=$USER_HOME/spy-venv/bin/python3 /usr/share/spyguard/server/backend/main.py
+ExecStart=$USER_HOME/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/backend/main.py
 Restart=on-abort
 KillMode=process
 
@@ -123,7 +123,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=$USER_HOME/spy-venv/bin/python3 /usr/share/spyguard/server/backend/watchers.py
+ExecStart=$USER_HOME/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/backend/watchers.py
 Restart=on-abort
 KillMode=process
 
@@ -186,7 +186,7 @@ check_dependencies() {
        fi
    done
    echo -e "\e[39m[+] Install Python packages...\e[39m"
-   python3 -m venv $USER_HOME/spy-venv && source $USER_HOME/spy-venv/bin/activate && python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
+   python3 -m venv $USER_HOME/SpyGuard-venv && source $USER_HOME/SpyGuard-venv/bin/activate && python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
 }
 
 get_version() {

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 
 CURRENT_USER="${SUDO_USER}"
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+USER_HOME=$(bash -c "cd ~$(printf %q $CURRENT_USER) && pwd")
 HOST="$( hostname )"
 LOCALES=(en fr es ru pt de it)
 
@@ -90,7 +91,7 @@ Description=Spyguard frontend service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/share/spyguard/server/frontend/main.py
+ExecStart=$USER_HOME/spy-venv/bin/python3 /usr/share/spyguard/server/frontend/main.py
 Restart=on-abort
 KillMode=process
 
@@ -105,7 +106,7 @@ Description=Spyguard backend service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/share/spyguard/server/backend/main.py
+ExecStart=$USER_HOME/spy-venv/bin/python3 /usr/share/spyguard/server/backend/main.py
 Restart=on-abort
 KillMode=process
 
@@ -122,7 +123,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /usr/share/spyguard/server/backend/watchers.py
+ExecStart=$USER_HOME/spy-venv/bin/python3 /usr/share/spyguard/server/backend/watchers.py
 Restart=on-abort
 KillMode=process
 
@@ -185,7 +186,7 @@ check_dependencies() {
        fi
    done
    echo -e "\e[39m[+] Install Python packages...\e[39m"
-   python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
+   python3 -m venv $USER_HOME/spy-venv && source $USER_HOME/spy-venv/bin/activate && python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
 }
 
 get_version() {
@@ -248,3 +249,5 @@ else
     feeding_iocs
     cleaning
 fi
+
+

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,6 @@
 
 CURRENT_USER="${SUDO_USER}"
 SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
-USER_HOME=$(bash -c "cd ~$(printf %q $CURRENT_USER) && pwd")
 HOST="$( hostname )"
 LOCALES=(en fr es ru pt de it)
 
@@ -91,7 +90,7 @@ Description=Spyguard frontend service
 
 [Service]
 Type=simple
-ExecStart=$USER_HOME/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/frontend/main.py
+ExecStart=/home/${SUDO_USER}/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/frontend/main.py
 Restart=on-abort
 KillMode=process
 
@@ -106,7 +105,7 @@ Description=Spyguard backend service
 
 [Service]
 Type=simple
-ExecStart=$USER_HOME/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/backend/main.py
+ExecStart=/home/${SUDO_USER}/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/backend/main.py
 Restart=on-abort
 KillMode=process
 
@@ -123,7 +122,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=$USER_HOME/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/backend/watchers.py
+ExecStart=/home/${SUDO_USER}/SpyGuard-venv/bin/python3 /usr/share/spyguard/server/backend/watchers.py
 Restart=on-abort
 KillMode=process
 
@@ -186,7 +185,7 @@ check_dependencies() {
        fi
    done
    echo -e "\e[39m[+] Install Python packages...\e[39m"
-   python3 -m venv $USER_HOME/SpyGuard-venv && source $USER_HOME/SpyGuard-venv/bin/activate && python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
+   python3 -m venv /home/${SUDO_USER}/SpyGuard-venv && source /home/${SUDO_USER}/SpyGuard-venv/bin/activate && python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
 }
 
 get_version() {

--- a/install.sh
+++ b/install.sh
@@ -184,8 +184,11 @@ check_dependencies() {
            install_package ${bin##*/}
        fi
    done
+   echo -e "\e[39m[+] Create and activate Virtual Environment for Python packages\e[39m"
+   python3 -m venv /usr/share/spyguard/spyguard-venv
+   source /usr/share/spyguard/spyguard-venv/bin/activate
    echo -e "\e[39m[+] Install Python packages...\e[39m"
-   python3 -m venv /usr/share/spyguard/spyguard-venv && source /usr/share/spyguard/spyguard-venv/bin/activate && python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
+   python3 -m pip install -r "$SCRIPT_PATH/assets/requirements.txt"
 }
 
 get_version() {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,7 +2,6 @@
 delete_folder(){
     echo "[+] Deleting Spyguard folders"
     rm -rf /usr/share/spyguard/
-    rm -rf /home/${SUDO_USER}/SpyGuard-venv
 }
 
 delete_services(){

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,6 +2,7 @@
 delete_folder(){
     echo "[+] Deleting Spyguard folders"
     rm -rf /usr/share/spyguard/
+    rm -rf /home/${SUDO_USER}/SpyGuard-venv
 }
 
 delete_services(){


### PR DESCRIPTION
All packages that were previously installed directly with pip are installed in a separate venv (/usr/share/spyguard/spyguard-venv).

Successfully tested with debian 11 (2023-12-05-raspios-bullseye-armhf-full) and debian 12 (2023-12-05-raspios-bookworm-arm64-full) on a Raspberry PI 4B.

A few changes will be added later, but it should be functional at the moment