### PR TITLE
adding some dependencies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,9 @@ packages=("tshark"
 	   "python3-pip"
 	   "python3-venv"
 	   "net-tools"
-           "python3-pil")
+           "python3-pil"
+	   "libpango-1.0"
+           "libpangoft2-1.0-0")
  
 echo -e "\e[39m[+] Checking dependencies...\e[39m"
 for package in "${packages[@]}"

--- a/install.sh
+++ b/install.sh
@@ -156,7 +156,8 @@ packages=("tshark"
 	   "dnsutils"
 	   "python3-pip"
 	   "python3-venv"
-	   "net-tools")
+	   "net-tools"
+           "python3-pil")
  
 echo -e "\e[39m[+] Checking dependencies...\e[39m"
 for package in "${packages[@]}"


### PR DESCRIPTION
we were trying to run the latest release, but doesn't work, so we started from master and we found Spyguard wasn't running due to some missing dependencies.

We tried via pip and via apt and we discover is needed by the system 
So deps are directly added into the install_packages function, hope that's fine

I've tested it and it works very clean on a rpi3b+ with raspbian on 32 bit.

We are adding them here hoping to be merged soon as other people can run Spyguard and improve it!

Thanks for all the work

Best,
samba